### PR TITLE
v0.0.6: Physics simulator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,9 @@ export DISK_OFFSET := 0
 
 # Size allocated to kernel in sectors. This must be able to fit boot.kern.bin, otherwise bad things will happen
 # Also used to determine load location in memory (loaded at 0x80_000 - KERN_SIZE{in bytes}. done so that it resides in the highest possible region in 640k that's not possible hoarded by bios).
-export KERN_SIZE := 112
+export KERN_SIZE := 116
 
-CFLAGS := -falign-functions=1 -fno-stack-protector -ffreestanding -m32 -march=i686 -Wall -Wextra -Werror=return-type -fpermissive -D"KERN_LEN=$(KERN_SIZE)"
+CFLAGS := -falign-functions=1 -fno-stack-protector -ffreestanding -m32 -march=i686 -Wall -Wextra -Werror=return-type -fpermissive -no-pie -D"KERN_LEN=$(KERN_SIZE)"
 CPPFLAGS := -fno-exceptions -fno-rtti -nostdinc++ $(CFLAGS)
 # -static-libgcc. contains some long long arithmetic stuff
 
@@ -23,8 +23,9 @@ build/boot.bin: src/boot.asm
 build/entry.o: src/kernel/entry.asm
 	nasm $^ -f elf -o $@
 
-build/apps.a: $(wildcard src/apps/*.cc) $(wildcard src/apps/extra/*.cc) $(wildcard src/apps/include/*.hh) $(wildcard src/apps/include/extra/*.hh)
+build/apps.a: src/apps/asm/physic.s $(wildcard src/apps/*.cc) $(wildcard src/apps/extra/*.cc) $(wildcard src/apps/include/*.hh) $(wildcard src/apps/include/extra/*.hh)
 	mkdir -p build/apps.obj
+	as $< --32 -o build/apps.obj/physic.asm.o
 	cd build/apps.obj && g++ $(CPPFLAGS) -c ../../src/apps/*.cc
 	cd build/apps.obj && g++ $(CPPFLAGS) -c ../../src/apps/extra/*.cc
 	ar rv $@ build/apps.obj/*.o

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ export DISK_OFFSET := 0
 
 # Size allocated to kernel in sectors. This must be able to fit boot.kern.bin, otherwise bad things will happen
 # Also used to determine load location in memory (loaded at 0x80_000 - KERN_SIZE{in bytes}. done so that it resides in the highest possible region in 640k that's not possible hoarded by bios).
-export KERN_SIZE := 116
+export KERN_SIZE := 120
 
 CFLAGS := -falign-functions=1 -fno-stack-protector -ffreestanding -m32 -march=i686 -Wall -Wextra -Werror=return-type -fpermissive -no-pie -D"KERN_LEN=$(KERN_SIZE)"
 CPPFLAGS := -fno-exceptions -fno-rtti -nostdinc++ $(CFLAGS)

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The kernel's source files are explained below:
 - `misc.c`: Definitions - structs, `#define`s, etc
 - `printf.c`: Contains `printf` and its variations. TODO: move this into a stdlib
 - `pic.c`: Utilities for initialising the PIC, masking the PIC, etc.
+- `sched.c`: Contains code for the kernel scheduler for kapps.
 - `syscall.c`: Contains code for `syscall`ing.
 - `text.c`: Code for writing to the screen.
 - `timer.c`: Code to control the PIT.

--- a/src/apps/asm/physic.s
+++ b/src/apps/asm/physic.s
@@ -165,7 +165,7 @@ _ZN6Physic6deinitEv:
 
 .section .rodata
   __physic_data_bounds: # dimensions of the screen, in the positiong cells: | 80 | 25 | 0 | 0 |
-    .word 25 # height
+    .word 24 # height - reduced to 24 to make way for bottom bar
     .word 80 # width
     .word 0 # not needed, as get_linear operates one at a time. TODO maybe?
     .word 0

--- a/src/apps/asm/physic.s
+++ b/src/apps/asm/physic.s
@@ -1,0 +1,190 @@
+.section .text
+
+# these are the mangled names for each function, which are static methods.
+.globl _ZN6Physic4initEjss
+.globl _ZN6Physic12compute_pairEPjS0_
+.globl _ZN6Physic10get_linearEj
+.globl _ZN6Physic14euclidean_normEPjPt
+.globl _ZN6Physic6deinitEv
+
+# performs packed euclidean norm of vectors
+_ZN6Physic14euclidean_normEPjPt: # mm* velocity vectors, u16* norm vector
+  movl 4(%esp), %edx # load ptr into edx
+
+  movq (%edx),  %mm2 # load vectors into mm2
+
+  pmaddwd %mm2, %mm2 # get | x_1^2 + y_1^2 | x_0^2 + y_0^2 |
+  cvtpi2ps %mm2, %xmm2 # convert them both into floats to do the sqrt. has to be in xmm for that
+  sqrtps %xmm2, %xmm2 # load the square roots into xmm2
+  cvtps2pi %xmm2, %mm2 # integer, cast back down to mm2 (and round, rather than truncate with cvtt)
+
+  # maximum possible is now 0xb505, which is cool because the norm is always unsigned
+  pshufw $0b01011000, %mm2, %mm2 # shuffle, because pack with unsigned saturation is too much to ask...
+  # packed into | 0 | 0 | m_1 | m_0 |
+
+  movl 8(%esp), %ecx # load output addr into ecx
+  movd %mm2, (%ecx) # load to output address
+
+  ret
+
+_ZN6Physic4initEjss: # u16 tick, i16 gravity, i16 wind
+  movw 4(%esp), %ax # load tick
+  movl $8, %ecx # repeat it eight times (128-bits)
+
+  pushl %edi
+  movl $__physic_data_tick, %edi
+  rep stosw # write tick to every word
+  popl %edi
+
+  # create acceleration word. e.g. | 0 | -9.81 | 0 | 0 |
+  /*
+    what we want to do:
+      movw 8(%esp), (acceleration + 4) # y-axis acceleration, needs to be low 16
+      movw 12(%esp), (acceleration + 6) # x-axis acceleration, needs to be high 16
+    unfortunately not possible, as cant move between two addresses. so we do simd magic
+  */
+
+  # load both parameters. this yields | 0 | a_x | 0 | a_y |
+  # | 0 | a_x | 0 | a_y | => | a_x | a_y | a_x | a_y |.
+  # we move this to higher using movd, as pshuf can't output to address
+  # packsswb isnt used as we then can't do memory magic
+  pshufw $0b10001000, 8(%esp), %mm6
+  movq %mm6, (__physic_data_acceleration)
+
+  ret
+
+# each object is represented by a packet of | v_x | v_y | x | y |
+# where each cell is a 16-bit fixed point (9.7) number, representing position.
+# 8000 and 7fff are the edges of the screen, so we can use signed saturation.
+# must be signed as we are decreasing.
+# v_x, v_y is the velocity vector.
+# x, y is the position vector
+_ZN6Physic12compute_pairEPjS0_: # mm* position vectors, mm* velocity vectors
+  movq (__physic_data_acceleration), %mm5 # mm5 <- a
+  pmullw (__physic_data_tick), %mm5 # mm5 = a * t. needed for both equations
+
+  # we use xmm stuff so as to do both at once
+  movq2dq %mm5, %xmm1 # xmm1 <- at
+  psraw $1, %xmm1 # xmm1 = .5at. needed for s = ut + .5at^2
+
+  pushl %esi
+  pushl %edi
+
+  movl 12(%esp), %esi # position vector ptr. 12 because we pushed esi and edi
+  movl 16(%esp), %edi # velocity vector ptr. 16 because ditto
+  # load velocity vector into low bytes of xmm
+  movq (%edi), %xmm0 # load velocity vector into low bytes of xmm
+
+  # calculating s = ut + .5at^2.
+  # what we do is we get a vector of the form | u_x | .5at_x | u_y | .5at_y | ... etc.
+  # (hence low unpack into xmm: we do both mms here, so xmm is used)
+  # which we then pmaddwd with t, to get | (ut+.5at^2)_x | (ut+.5at^2)_y |.
+  punpcklwd %xmm0, %xmm1 # unpack low into vector
+  pmaddwd (__physic_data_tick), %xmm1 # pmaddwd with t
+  packssdw %xmm1, %xmm1 # squash back down into 16bit words. we use itself cause we don't care about high 32
+  movdq2q %xmm1, %mm4 # mm4 = Ds packet
+
+  paddsw (%edi), %mm5 # add Dv packet. .5at is already saved, so we don't care
+  paddsw (%esi), %mm4 # add Ds packet.
+  # save them
+  movq %mm5, (%edi)
+  movq %mm4, (%esi)
+
+  call __physic_bounce_post_save
+
+  popl %edi # undo push
+  popl %esi
+  ret # eax is now linear coordinate
+
+_ZN6Physic10get_linearEj: # get_linear(u32 pos)
+  # now, we get new position offsets to our draw function
+  movd 4(%esp), %mm0
+  pxor (__physic_data_invert_mask), %mm0 # our mask.
+        # this mask inverts top bits, to shift signed into unsigned
+        # (as we've been saturating signedly), and also inverts again the whole of y axis
+        # as the origin is in top-left, not top-right as we might expect
+
+  # unsigned multiply, becuase we've now normalised them to unsigned
+  pmulhuw (__physic_data_bounds), %mm0 # normalise our 0x0000-0xffff to 0-80 and 0-25.
+    # we do this by multiplying them by the desired width, and only take the high 16 of each.
+
+  movd %mm0, %edx  # edx is now valid coordinates (x, y), with x taking up high 16
+
+  movb $80, %al    # multiply y by 80 to get linear coordinate, and put it in al
+  mulb %dl
+
+  shrl $16, %edx # get high 16 (x coordinate) from packet
+  addw %dx, %ax # add x coordinate
+
+  ret
+
+# check for bouncing. if it is at the edges (e.g. y = 0x8000), bounce
+__physic_bounce_post_save:
+  # we want to check both 0x7fff and 0x8000. thankfully, our invert mask from earlier does the trick...
+  # both are used as it inverts it later
+  movq (__physic_data_edge_check_1), %mm4 # bounce
+  pcmpeqw (%esi), %mm4 # mm4 now stores if position packets are equal to first bounce
+
+  movq (__physic_data_edge_check_2), %mm5 # bounce
+  pcmpeqw (%esi), %mm5 # mm5 now stores if ditto for second bounce
+
+  por %mm4, %mm5 # mm5 now stores final mask.
+
+  movq (__physic_data_restitution_coeffs), %mm4
+
+  /*
+    what we want to do:
+      # special multiply, that does (((a * b) >> 14) + 1) >> 1 \approx (a*b) >> 15.
+      # best way to negate and multiply.
+      pmulhrsw (%edi), %mm4 # multiply velocity packet by scale factors.
+                            # mm4 is now the scaled "bounced" velocity.
+    not possible, as pmulhrsw is ssse3 only.
+    this is bad, because we can only now store coefficients down to -0.5 in 16 bits.
+    we thus keep our coefficients equal (halving them), then shl by 1 to account for inaccuracy
+  */
+  pmulhw (%edi), %mm4 # multiply velocity packet by scale factors.
+  psllw $1, %mm4      # shift left to account for inaccuracy
+                      # mm4 is now the scaled "bounced" velocity.
+
+  # note: this takes edi as implicit parameter. good thing it's already set...
+  maskmovq %mm5, %mm4 # selectively write the bounced data when mask says it's equal.
+
+  ret
+
+_ZN6Physic6deinitEv:
+  emms
+  ret
+
+.section .bss
+.align 16 # xmm pmaddwd chokes if it's not aligned (my guess is it throws out the bottom few bits)
+  __physic_data_tick: # xmm word, as it used for pmaddwd
+    .octa 0
+
+  __physic_data_acceleration: # storing the acceleration word.
+    .long 0
+
+.section .rodata
+  __physic_data_bounds: # dimensions of the screen, in the positiong cells: | 80 | 25 | 0 | 0 |
+    .word 25 # height
+    .word 80 # width
+    .word 0 # not needed, as get_linear operates one at a time. TODO maybe?
+    .word 0
+
+  __physic_data_edge_check_1: # edge checking in bounce code. like this so that we can reuse the start of invert_mask
+    .word 0x8000
+
+  __physic_data_edge_check_2:
+  __physic_data_invert_mask: # used for xoring to invert the y axis because of moving origin
+               # also flips the top bit, which shifts our signed numbers into unsigned
+    .word 0x7fff
+    .word 0x8000
+    .word 0x7fff
+    .word 0x8000
+    # .word 0
+    # .word 0 # these are repeated next, so as to not repeat myself i've commented them out
+
+  __physic_data_restitution_coeffs: # create | -0.6 | -0.8 | -0.6 | -0.8 |, which are the negatives of the coefficients of restitution. walls absorb more kinetic energy than floor/ceiling, so absorb 40% rather than 20%
+    .word 0xb333 # -0.6
+    .word 0x999a # -0.8
+    .word 0xb333 # -0.6
+    .word 0x999a # -0.8

--- a/src/apps/asm/physic.s
+++ b/src/apps/asm/physic.s
@@ -1,14 +1,14 @@
 .section .text
 
-# these are the mangled names for each function, which are static methods.
+# these are the mangled names for each function, which are static methods in Physic.
 .globl _ZN6Physic4initEjss
 .globl _ZN6Physic12compute_pairEPjS0_
-.globl _ZN6Physic10get_linearEj
-.globl _ZN6Physic14euclidean_normEPjPt
+.globl _ZN6Physic10get_linearEjb
+.globl _ZN6Physic14euclidean_normEPKjPt
 .globl _ZN6Physic6deinitEv
 
 # performs packed euclidean norm of vectors
-_ZN6Physic14euclidean_normEPjPt: # mm* velocity vectors, u16* norm vector
+_ZN6Physic14euclidean_normEPKjPt: # mm* velocity vectors, u16* norm vector
   movl 4(%esp), %edx # load ptr into edx
 
   movq (%edx),  %mm2 # load vectors into mm2
@@ -96,9 +96,10 @@ _ZN6Physic12compute_pairEPjS0_: # mm* position vectors, mm* velocity vectors
   popl %esi
   ret # eax is now linear coordinate
 
-_ZN6Physic10get_linearEj: # get_linear(u32 pos)
+_ZN6Physic10get_linearEjb: # get_linear(u32 pos, bool is_squashed)
   # now, we get new position offsets to our draw function
   movd 4(%esp), %mm0
+  movl 8(%esp), %ecx # take whether it is squashed (i.e. in splitscreen, so vp is halved) as a bool
   pxor (__physic_data_invert_mask), %mm0 # our mask.
         # this mask inverts top bits, to shift signed into unsigned
         # (as we've been saturating signedly), and also inverts again the whole of y axis
@@ -109,6 +110,13 @@ _ZN6Physic10get_linearEj: # get_linear(u32 pos)
     # we do this by multiplying them by the desired width, and only take the high 16 of each.
 
   movd %mm0, %edx  # edx is now valid coordinates (x, y), with x taking up high 16
+
+  test %ecx, %ecx
+  jz .after_squash
+
+  shrb $1, %dl # halve y axis if squashing is necessary
+
+.after_squash:
 
   movb $80, %al    # multiply y by 80 to get linear coordinate, and put it in al
   mulb %dl

--- a/src/apps/helphost.cc
+++ b/src/apps/helphost.cc
@@ -94,6 +94,16 @@ void HelpHost::put_entries() {
       }
       
       goto _helphost_post_entry;
+    } else if (this -> ents[ent].type & SYNOPSIS) { // write just plain text.
+      if (strlen(this->ents[ent].desc) > (VGA_WIDTH - 4)) { // if overboard
+        // minus 7 to make room for ellipsis
+        nprintf(VGA_WIDTH - 7, "%$%s", COLOUR(BLUE, B_WHITE), this->ents[ent].desc);
+        write_str("...", COLOUR(BLUE, WHITE));
+      } else {
+        write_str(this->ents[ent].desc, COLOUR(BLUE, B_WHITE));
+      }
+
+      goto _helphost_post_entry;
     }
 
     // sub entry (indent)

--- a/src/apps/include/extra/fromc.hh
+++ b/src/apps/include/extra/fromc.hh
@@ -19,6 +19,7 @@ extern "C" {
 #include "../../../kernel/include/memring.h"
 #include "../../../kernel/include/misc.h"
 #include "../../../kernel/include/printf.h"
+#include "../../../kernel/include/sched.h"
 #include "../../../kernel/include/text.h"
 #include "../../../kernel/include/util.h"
 }

--- a/src/apps/include/helphost.hh
+++ b/src/apps/include/helphost.hh
@@ -15,6 +15,7 @@ public:
     SUB_ENTRY = 1 << 0, // indented, and preceded by a colon
     DEBUG_ENTRY = 1 << 1, // lighter text, "greyed out"
     DIVIDER = 1 << 2, // a load of dashes
+    SYNOPSIS = 1 << 3, // a straight line of text.
     TERMINATE = -1,
   };
 

--- a/src/apps/include/kapp.hh
+++ b/src/apps/include/kapp.hh
@@ -32,4 +32,7 @@ extern "C" struct KApp { // struct != class, class is everything's private by de
 protected: // only visible to this and children
   // write keys util function, see kapp.cc for more info
   int write_keys_to_buf(struct inp_strbuf *);
+
+  // bad sleep function. basically trigger invoke again after a set amount of time to keep alive, but not hogging computer with busy wait
+  void invoke_after_centisecs(unsigned int delta);
 };

--- a/src/apps/include/physic.hh
+++ b/src/apps/include/physic.hh
@@ -14,6 +14,8 @@ struct Physic : KApp {
   void first_run();
 
 private:
+  unsigned int frame; // frame number
+
   // linear addresses of current pieces
   curpos_t linear[N_PIECES];
 
@@ -35,6 +37,7 @@ private:
   bool paused; // true if paused
 
   void tick_and_draw();
+  void title();
 
   /* external asm functions. static as they don't reference this pointer, so don't need to be passed it */
   static void init(unsigned int ticks_per_frame, short gravity, short tilt);

--- a/src/apps/include/physic.hh
+++ b/src/apps/include/physic.hh
@@ -39,11 +39,14 @@ private:
   void tick_and_draw();
   void title();
 
+  // helper function to paint piece
+  static struct char_packet paint_piece(struct char_packet piece, unsigned char bg);
+
   /* external asm functions. static as they don't reference this pointer, so don't need to be passed it */
   static void init(unsigned int ticks_per_frame, short gravity, short tilt);
   static void compute_pair(packet_t *pos_packet, packet_t *vel_packet);
-  static curpos_t get_linear(packet_t pos);
-  static void euclidean_norm(packet_t *vel_packet, unsigned short *norms);
+  static curpos_t get_linear(packet_t pos, bool is_squashed);
+  static void euclidean_norm(const packet_t *vel_packet, unsigned short *norms);
   static void deinit();
 
 public:

--- a/src/apps/include/physic.hh
+++ b/src/apps/include/physic.hh
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "kapp.hh"
+#include "extra/fromc.hh"
+
+typedef unsigned int packet_t;
+
+// number of pieces
+#define N_PIECES 2
+
+struct Physic : KApp {
+  // virtual methods
+  void invoke();
+  void first_run();
+
+private:
+  // linear addresses of current pieces
+  curpos_t linear[N_PIECES];
+
+  // packet data
+  packet_t pos[N_PIECES];
+  packet_t vel[N_PIECES];
+
+  // euclidean norms of velocity
+  unsigned short vel_norm[N_PIECES];
+
+  struct char_packet pieces[N_PIECES];
+
+  /* runtime variables */
+
+  // x and y axis acceleration respectively
+  short tilt;
+  short gravity;
+
+  bool paused; // true if paused
+
+  void tick_and_draw();
+
+  /* external asm functions. static as they don't reference this pointer, so don't need to be passed it */
+  static void init(unsigned int ticks_per_frame, short gravity, short tilt);
+  static void compute_pair(packet_t *pos_packet, packet_t *vel_packet);
+  static curpos_t get_linear(packet_t pos);
+  static void euclidean_norm(packet_t *vel_packet, unsigned short *norms);
+  static void deinit();
+
+public:
+  Physic();
+  ~Physic();
+};

--- a/src/apps/kapp.cc
+++ b/src/apps/kapp.cc
@@ -11,6 +11,7 @@
 #include "include/edit.hh"
 #include "include/shell.hh"
 #include "include/calc.hh"
+#include "include/err.h"
 
 KApp::KApp() {
   memzero(&key_q, QUEUE_LEN);
@@ -23,7 +24,7 @@ int KApp::write_keys_to_buf(struct inp_strbuf *to) {
   // if we'll be past the end of the buffer's allocation (comlen)
   // it'll error anyway, no point in putting characters
   char n_to_put = strlen(this->key_q);
-  if (!n_to_put) return; // nothing to do beyond this point
+  if (!n_to_put) return strlen(to->buf); // nothing to do beyond this point
 
   int targ_len = strlen(to->buf) + n_to_put;
   if (targ_len >= to->len) {
@@ -42,6 +43,11 @@ int KApp::write_keys_to_buf(struct inp_strbuf *to) {
 
   return targ_len;
 }
+
+// bad wait function: wrapper around set_timed_invoke
+void KApp::invoke_after_centisecs(unsigned int delta) {
+  set_timed_invoke(this->app_id & 0xf, delta);
+};
 
 // we dont technically need to destruct anything, but out children might (but if we don't know they're a child we need virtuality)
 KApp::~KApp() {};

--- a/src/apps/kapp.cc
+++ b/src/apps/kapp.cc
@@ -11,7 +11,6 @@
 #include "include/edit.hh"
 #include "include/shell.hh"
 #include "include/calc.hh"
-#include "include/err.h"
 
 KApp::KApp() {
   memzero(&key_q, QUEUE_LEN);

--- a/src/apps/physic.cc
+++ b/src/apps/physic.cc
@@ -1,0 +1,116 @@
+#include "include/physic.hh"
+
+#include "include/extra/fromc.hh"
+
+/*
+extern void __physic_init(unsigned int ticks_per_frame, short gravity, short tilt);
+extern void __physic_compute_pair(packet_t *pos_packet, packet_t *vel_packet);
+extern curpos_t __physic_get_linear(packet_t pos);
+extern void __physic_euclidean_norm(packet_t *vel_packet, unsigned short *norms);
+extern void __physic_deinit();
+*/
+
+// all numbers are in 9.7 fixed point.
+// the integer part is supposed to be hectometres, which means the arena is 51.2x51.2km wide, but also making one single unit about 78cm.
+// this is quite ridiculous, but we need to zoom out as otherwise the gravity is too fast to appreciate.
+// this is also somewhat distorted into a 720x400 text mode screen, but it still doesn't look too strange.
+
+// the smallest unit of time that can be represented in 9.7fix is 1/128sec, which i shall call 1 tick.
+// 4 ticks per frame is the best tradeoff between least choppy and closest to an integer number of centiseconds (i.e. 3.125cs \approx 3cs)
+
+/*
+  for posterity, the list of reasonable errors:
+    1 => 0.0021875
+    4 => 0.0012499999999999994
+    5 => 0.0009375000000000008
+    9 => 0.00031249999999999854
+    32 => 5.204170427930421e-18
+
+  and the julia code for generating them:
+    all = 1:128 .|> x -> x => min(x/128 % 0.01, 0.01 - (x/128 % 0.01))
+    max = 0 => 1
+    for pair in all
+      if last(pair) < last(max)
+          max = pair
+          println(max)
+      end
+    end
+*/
+
+// 4/128sec in 9.7 fixed point. see above
+#define TICKS_PER_FRAME 4
+#define CS_PER_FRAME 3
+
+// approximation of -0.0981 hm/s^2 in 9.7 fixed point.
+// -0.0981hm/s^2 * 128 = 12.552515...
+#define GRAVITY -12
+
+void Physic::invoke() {
+  for (int i = 0; i < QUEUE_LEN && !!this->ctrl_q[i]; ++i) { // loop over each arrow key
+    switch (this -> ctrl_q[i]) {
+      default: break;
+    }
+
+    ctrl_q[i] = NO_CTRL;
+  }
+
+  if (this -> key_q[0]) { // press any key to continue...
+    terminate_app(this->app_id & 0xf);
+  }
+
+  this->tick_and_draw();
+}
+
+void Physic::first_run() { this->tick_and_draw(); }
+
+void Physic::tick_and_draw() {
+  // do nothing if paused
+  if (paused) return;
+
+  this->compute_pair(this->pos, this->vel);
+
+  // over each piece
+  for (int piece = 0; piece < N_PIECES; ++piece) {
+    // wipe old location. style = 0.
+    write_cell(' ', linear[piece], 0);
+
+    // get new linear location
+    linear[piece] = this->get_linear(pos[piece]);
+
+    // write piece
+    write_cell_packet(linear[piece], pieces[piece], false);
+  }
+}
+
+Physic::Physic() {
+  // bitflags, or as many together as need be
+  config_flags = 0; // we frankly don't care about enter, so its flag is just your favourite bit
+
+  app_name = "physic";
+
+  // setup
+  {
+    pos[0] = 0xc000'7fff; // (20, 0)
+    vel[0] = 0x0080'0000; // [0.15625, 0]
+
+    pos[1] = 0x4000'5fff; // (60, 10)
+    vel[1] = 0xff00'f000; // [-0.3125, -1.5625]
+
+    // yellow hash and pick asterisk
+    pieces[0] = { '#', COLOUR(BLACK, B_YELLOW) };
+    pieces[1] = { '*', COLOUR(BLACK, B_MAGENTA) };
+
+    // set accelerations
+    tilt = 0;
+    gravity = GRAVITY;
+
+    paused = false;
+  }
+
+  //__physic_init(TICKS_PER_FRAME, gravity, tilt); // init data
+  this->init(TICKS_PER_FRAME, gravity, tilt); // init data
+}
+
+Physic::~Physic() {
+  this->deinit(); // deinit
+}

--- a/src/apps/physic.cc
+++ b/src/apps/physic.cc
@@ -1,6 +1,7 @@
 #include "include/physic.hh"
 
 #include "include/extra/fromc.hh"
+#include "include/helphost.hh"
 
 /*
 extern void __physic_init(unsigned int ticks_per_frame, short gravity, short tilt);
@@ -37,6 +38,16 @@ extern void __physic_deinit();
     end
 */
 
+const HelpHost::Entry help_data[] = {
+  { .name = "<Esc>", .desc = "Quit", .type = HelpHost::PLAIN_ENTRY },
+  { .name = "^H", .desc = "Show this help menu", .type = HelpHost::PLAIN_ENTRY },
+  { .name = "[HJKL]", .desc = "Control gravity", .type = HelpHost::PLAIN_ENTRY },
+  { .name = "J/K", .desc = "Set gravity to point down/up", .type = HelpHost::SUB_ENTRY },
+  { .name = "H/L", .desc = "Increase left/right tilt by one", .type = HelpHost::SUB_ENTRY },
+  { .name = "Space", .desc = "Play/pause", .type = HelpHost::PLAIN_ENTRY },
+  { .type = HelpHost::TERMINATE }
+};
+
 // 4/128sec in 9.7 fixed point. see above
 #define TICKS_PER_FRAME 4
 #define CENTISEC_PER_FRAME 3
@@ -72,17 +83,39 @@ void Physic::invoke() {
       break;
     reset: // call init again with new settings
       this->init(TICKS_PER_FRAME, gravity, tilt);
+      this->title(); // fix title
     }
 
     key_q[i] = NO_CTRL;
   }
 
-  if (this -> ctrl_q[0]) { // press any control key to continue...
-    terminate_app(this->app_id & 0xf);
-    return;
+  bool drawing = true;
+
+  for (int i = 0; i < QUEUE_LEN && !!this->ctrl_q[i]; ++i) { // loop over each arrow key
+    switch (this -> ctrl_q[i]) {
+      case NO_CTRL: break; // already dealt with, should never happen
+      case CTRL(H): {
+        app_handle help = instantiate(
+          new HelpHost("physics simulator", help_data),
+          this->app_id & 0xf,
+          true
+        );
+        drawing = false;
+        break;
+      }
+      case ESC: {
+        terminate_app(this->app_id & 0xf);
+        return;
+      }
+      default: break; // nothing else
+    }
+
+    ctrl_q[i] = NO_CTRL;
   }
 
-  this->tick_and_draw();
+  if (drawing) this->tick_and_draw();
+
+  next_step:
   this->invoke_after_centisecs(CENTISEC_PER_FRAME);
 }
 
@@ -106,41 +139,52 @@ void Physic::tick_and_draw() {
   // over each piece
   for (int piece = 0; piece < N_PIECES; ++piece) {
     // wipe old location. style = 0.
-    write_cell(' ', linear[piece], 0);
+    write_cell(' ', linear[piece] + VGA_WIDTH, 0);
 
     // get new linear location
-    linear[piece] = this->get_linear(pos[piece]);
+    linear[piece] = this->get_linear(pos[piece], (VP_HEIGHT < VGA_HEIGHT));
 
     // write piece
-    write_cell_packet(linear[piece], pieces[piece], false);
+    write_cell_packet(linear[piece] + VGA_WIDTH, pieces[piece], false);
   }
 
   this->title();
 }
 
+// helper function to paint piece
+struct char_packet Physic::paint_piece(struct char_packet piece, unsigned char bg) {
+  struct char_packet mod = piece;
+  mod.style &= 0xf;
+  mod.style |= bg << 4;
+  return mod;
+}
+
 void Physic::title() {
-  set_cur(POS(0, 24));
-  printf("\r%$%~: (%2d,%2d) %u \xeb/s \xb3 %~: (%2d,%2d) %u \xeb/s %$\xb3 T: %~ %u, G: %~ \xb3 %$ ^H = help %$",
-    COLOUR(BLACK, B_WHITE),
-    pieces[0],
+  set_cur(POS(0, 0));
+  printf("\r%$ %~: (%2d,%2d) %u \xeb/s \xb3 %~: (%2d,%2d) %u \xeb/s %$\xb3 T: %~ %u, G: %~ \xb3 %$^H %$= help",
+    COLOUR(BLUE, B_WHITE),
+    this->paint_piece(pieces[0], BLUE),
     linear[0] % 80,
     linear[0] / 80,
     vel_norm[0],
-    pieces[1],
+    this->paint_piece(pieces[1], BLUE),
     linear[1] % 80,
     linear[1] / 80,
     vel_norm[1],
-    COLOUR(BLACK, WHITE),
-    (struct char_packet) {tilt > 0 ? '\x1a' : tilt == 0 ? '\xf9' : '\x1b', COLOUR(BLACK, B_CYAN)},
+    COLOUR(BLUE, WHITE),
+    (struct char_packet) { tilt > 0 ? '\x1a' : tilt == 0 ? '\xf9' : '\x1b', COLOUR(BLUE, B_CYAN) },
     tilt > 0 ? tilt : -tilt,
-    (struct char_packet) { gravity > 0 ? '\x18' : gravity == 0 ? '\xf9' : '\x19', COLOUR(BLACK, B_GREEN)},
-    COLOUR(RED, B_YELLOW),
-    COLOUR(BLACK, WHITE)
+    (struct char_packet) { gravity > 0 ? '\x18' : gravity == 0 ? '\xf9' : '\x19', COLOUR(BLUE, B_GREEN)},
+    COLOUR(BLUE, B_CYAN),
+    COLOUR(BLUE, CYAN)
   );
-  for (curpos_t cur = get_cur(); cur < (VGA_WIDTH * VGA_HEIGHT); ++cur) {
-    write_cell(0, cur, 0); // empty rest of line
+
+  for (curpos_t cur = get_cur(); cur < VGA_WIDTH; ++cur) {
+    write_cell(0, cur, COLOUR(BLUE, BLUE)); // empty rest of line
   }
-  write_cell(paused ? '\xfe' : '\xff', POS(VGA_WIDTH - 2, VGA_HEIGHT - 1), COLOUR(B_BLACK, B_RED));
+
+  // flashing red square when paused, otherwise blank (doesn't work too well on qemu)
+  write_cell(paused ? '\xfe' : '\xff', POS(VGA_WIDTH - 2, 0), COLOUR(B_BLUE, B_RED));
 }
 
 Physic::Physic() {

--- a/src/apps/physic.cc
+++ b/src/apps/physic.cc
@@ -41,10 +41,17 @@ extern void __physic_deinit();
 const HelpHost::Entry help_data[] = {
   { .name = "<Esc>", .desc = "Quit", .type = HelpHost::PLAIN_ENTRY },
   { .name = "^H", .desc = "Show this help menu", .type = HelpHost::PLAIN_ENTRY },
+  { .name = "^W", .desc = "Reset screen (if some pieces stuck)", .type = HelpHost::PLAIN_ENTRY },
+  { .type = HelpHost::DIVIDER },
   { .name = "[HJKL]", .desc = "Control gravity", .type = HelpHost::PLAIN_ENTRY },
   { .name = "J/K", .desc = "Set gravity to point down/up", .type = HelpHost::SUB_ENTRY },
   { .name = "H/L", .desc = "Increase left/right tilt by one", .type = HelpHost::SUB_ENTRY },
   { .name = "Space", .desc = "Play/pause", .type = HelpHost::PLAIN_ENTRY },
+  { .type = HelpHost::DIVIDER },
+  { .desc = "Topbar shows co-ords and speed (in 65536ths of arena, i.e. \xeb) of each piece,", .type = HelpHost::SYNOPSIS },
+  { .desc = "and then shows the current tilt factor, then whether gravity is up or down.", .type = HelpHost::SYNOPSIS },
+  { .desc = "Tilt can be changed and gravity can be flipped with HJKL, as above.", .type = HelpHost::SYNOPSIS },
+  { .desc = "A flashing red \xfe indicates paused, and the frame number is in the top left.", .type = HelpHost::SYNOPSIS },
   { .type = HelpHost::TERMINATE }
 };
 
@@ -101,6 +108,10 @@ void Physic::invoke() {
           true
         );
         drawing = false;
+        break;
+      }
+      case CTRL(W): {
+        clear_scr(); // clear screen
         break;
       }
       case ESC: {
@@ -161,7 +172,10 @@ struct char_packet Physic::paint_piece(struct char_packet piece, unsigned char b
 
 void Physic::title() {
   set_cur(POS(0, 0));
-  printf("\r%$ %~: (%2d,%2d) %u \xeb/s \xb3 %~: (%2d,%2d) %u \xeb/s %$\xb3 T: %~ %u, G: %~ \xb3 %$^H %$= help",
+  printf("\r%$ %u %$\xb3%$ %~: (%2d,%2d) %u \xeb/s \xb3 %~: (%2d,%2d) %u \xeb/s %$\xb3 T: %~ %u, G: %~ \xb3 %$^H %$= help",
+    COLOUR(BLUE, B_RED),
+    frame,
+    COLOUR(BLUE, WHITE),
     COLOUR(BLUE, B_WHITE),
     this->paint_piece(pieces[0], BLUE),
     linear[0] % 80,

--- a/src/apps/physic.cc
+++ b/src/apps/physic.cc
@@ -39,35 +39,69 @@ extern void __physic_deinit();
 
 // 4/128sec in 9.7 fixed point. see above
 #define TICKS_PER_FRAME 4
-#define CS_PER_FRAME 3
+#define CENTISEC_PER_FRAME 3
 
 // approximation of -0.0981 hm/s^2 in 9.7 fixed point.
 // -0.0981hm/s^2 * 128 = 12.552515...
 #define GRAVITY -12
 
 void Physic::invoke() {
-  for (int i = 0; i < QUEUE_LEN && !!this->ctrl_q[i]; ++i) { // loop over each arrow key
-    switch (this -> ctrl_q[i]) {
-      default: break;
+  for (int i = 0; i < QUEUE_LEN && !!this->key_q[i]; ++i) { // loop over each arrow key
+    switch (this -> key_q[i]) {
+    case 'H': // tilt left
+    case 'h':
+      this->tilt--;
+      goto reset;
+    case 'J': // set gravity down
+    case 'j':
+      if (this->gravity > 0) gravity = -gravity;
+      goto reset;
+    case 'K': // set gravity up
+    case 'k':
+      if (this->gravity < 0) gravity = -gravity;
+      goto reset;
+    case 'L': // tilt right
+    case 'l':
+      this->tilt++;
+      goto reset;
+    case ' ': // space to pause
+      this->paused = !paused;
+      this->title(); // update pause indicator
+      break;
+    default:
+      break;
+    reset: // call init again with new settings
+      this->init(TICKS_PER_FRAME, gravity, tilt);
     }
 
-    ctrl_q[i] = NO_CTRL;
+    key_q[i] = NO_CTRL;
   }
 
-  if (this -> key_q[0]) { // press any key to continue...
+  if (this -> ctrl_q[0]) { // press any control key to continue...
     terminate_app(this->app_id & 0xf);
+    return;
   }
 
   this->tick_and_draw();
+  this->invoke_after_centisecs(CENTISEC_PER_FRAME);
 }
 
-void Physic::first_run() { this->tick_and_draw(); }
+void Physic::first_run() {
+  this->invoke(); // trigger tick and loop
+}
 
 void Physic::tick_and_draw() {
   // do nothing if paused
   if (paused) return;
 
+  this->frame++;
+
   this->compute_pair(this->pos, this->vel);
+
+  // every other frame, calculate velocity
+  if (this->frame & 1) {
+    this->euclidean_norm(this->vel, this->vel_norm);
+  }
 
   // over each piece
   for (int piece = 0; piece < N_PIECES; ++piece) {
@@ -80,6 +114,33 @@ void Physic::tick_and_draw() {
     // write piece
     write_cell_packet(linear[piece], pieces[piece], false);
   }
+
+  this->title();
+}
+
+void Physic::title() {
+  set_cur(POS(0, 24));
+  printf("\r%$%~: (%2d,%2d) %u \xeb/s \xb3 %~: (%2d,%2d) %u \xeb/s %$\xb3 T: %~ %u, G: %~ \xb3 %$ ^H = help %$",
+    COLOUR(BLACK, B_WHITE),
+    pieces[0],
+    linear[0] % 80,
+    linear[0] / 80,
+    vel_norm[0],
+    pieces[1],
+    linear[1] % 80,
+    linear[1] / 80,
+    vel_norm[1],
+    COLOUR(BLACK, WHITE),
+    (struct char_packet) {tilt > 0 ? '\x1a' : tilt == 0 ? '\xf9' : '\x1b', COLOUR(BLACK, B_CYAN)},
+    tilt > 0 ? tilt : -tilt,
+    (struct char_packet) { gravity > 0 ? '\x18' : gravity == 0 ? '\xf9' : '\x19', COLOUR(BLACK, B_GREEN)},
+    COLOUR(RED, B_YELLOW),
+    COLOUR(BLACK, WHITE)
+  );
+  for (curpos_t cur = get_cur(); cur < (VGA_WIDTH * VGA_HEIGHT); ++cur) {
+    write_cell(0, cur, 0); // empty rest of line
+  }
+  write_cell(paused ? '\xfe' : '\xff', POS(VGA_WIDTH - 2, VGA_HEIGHT - 1), COLOUR(B_BLACK, B_RED));
 }
 
 Physic::Physic() {
@@ -90,6 +151,8 @@ Physic::Physic() {
 
   // setup
   {
+    frame = 0;
+
     pos[0] = 0xc000'7fff; // (20, 0)
     vel[0] = 0x0080'0000; // [0.15625, 0]
 

--- a/src/apps/shell.cc
+++ b/src/apps/shell.cc
@@ -4,6 +4,7 @@
 #include "include/extra/split.hh"
 
 #include "include/shell.hh"
+#include "include/physic.hh"
 
 // list of entries, Entry and EntType are children of HelpHost
 const HelpHost::Entry comnames[] = {
@@ -20,6 +21,7 @@ const HelpHost::Entry comnames[] = {
   { .name = "edit", .desc = "Text editor\xff<filename>", .type = HelpHost::SUB_ENTRY },
   { .name = "read", .desc = "Prints file content\xff<filename>", .type = HelpHost::SUB_ENTRY },
   { .name = "help", .desc = "Prints this help menu", .type = HelpHost::PLAIN_ENTRY },
+  { .name = "physic", .desc = "Launches a SIMD physics simulator", .type = HelpHost::PLAIN_ENTRY },
   { .name = "proc", .desc = "Utilities that manage running processes", .type = HelpHost::PLAIN_ENTRY },
   { .name = "ls", .desc = "Prints currently running processes", .type = HelpHost::SUB_ENTRY },
   { .name = "kill", .desc = "Kills the specified process\xff<@handle>", .type = HelpHost::SUB_ENTRY },
@@ -330,6 +332,15 @@ shell_f_stat:
   } else if (strcmp(argv[0], "help")) {
     app_handle help = instantiate(
       new HelpHost("shell builtins", comnames),
+      this->app_id & 0xf,
+      true
+    );
+
+    exitting = false;
+    goto shell_clean;
+  } else if (strcmp(argv[0], "physic")) {
+    app_handle edt = instantiate(
+      new Physic(),
       this->app_id & 0xf,
       true
     );

--- a/src/kernel/ata.c
+++ b/src/kernel/ata.c
@@ -2,6 +2,7 @@
 #include "include/err.h"
 #include "include/fs.h"
 #include "include/port.h"
+#include "include/sched.h"
 
 // see TODO in header file
 unsigned short *ata_identity = (unsigned short *) 0xd000;

--- a/src/kernel/cmos.c
+++ b/src/kernel/cmos.c
@@ -7,8 +7,6 @@
 
 struct timestamp *curr_time = (struct timestamp *) 0xc7f0;
 
-// centisec (100ths of sec) since load
-unsigned int uptime = 0;
 char *weekmap[7] = {
   "Sun",
   "Mon",

--- a/src/kernel/entry.asm
+++ b/src/kernel/entry.asm
@@ -164,6 +164,34 @@ print_32:
         popad ; popa but 32bit
         ret
 
+[global sse_enable]
+sse_enable: ; enable sse
+        mov eax, 0x1 ; cpuid leaf 1
+        cpuid ; get cpuid
+        test edx, (1 << 25) ; bit 25 of edx => sse
+
+        clc ; clear carry flag (false)
+        jz .sse_end
+
+        ; enable sse, taken from osdev wiki (q.v.)
+        mov eax, cr0 ; get cr0
+        and ax, 0xfffb ; clear bit 2
+        or ax, 0x2     ; set bit 1
+        mov cr0, eax ; save cr0
+
+        mov eax, cr4 ; get cr4
+        or ax, 0x0600 ; set bits 9 and 10
+        mov cr4, eax ; save cr4
+
+        stc ; set carry flag (true)
+
+  .sse_end:
+        setc cl
+        movzx eax, cl
+
+        ret
+
+
 protected:
         db "Successfully moved into Protected Mode!",0
 

--- a/src/kernel/ih.c
+++ b/src/kernel/ih.c
@@ -6,6 +6,7 @@
 #include "include/cmos.h"
 #include "include/misc.h"
 #include "include/pic.h"
+#include "include/sched.h"
 
 unsigned char quitting_prog = 0;
 
@@ -50,6 +51,7 @@ void eh_c(struct cpu_state c, unsigned int i, struct stack_state s) {
     if (!(++uptime % 100)) {
       adv_time(curr_time);
     } // increment centisecond counter
+    tick_focused_timed_invoke(); // tick program if available
     break;
   case 0x21: // PS/2 keyboard
     read_kbd(); // send to the keyboard

--- a/src/kernel/include/cmos.h
+++ b/src/kernel/include/cmos.h
@@ -31,7 +31,6 @@ struct timestamp {
 } __attribute__((packed));
 
 extern struct timestamp *curr_time;
-extern unsigned int uptime;
 extern char *weekmap[7];
 
 void read_rtc(struct timestamp *ts);

--- a/src/kernel/include/hwinf.h
+++ b/src/kernel/include/hwinf.h
@@ -52,7 +52,9 @@ struct hwinf {
 
   unsigned int f_flags_edx; // 0xcc8f
   unsigned int f_flags_ecx; // 0xcc93
-                            // 0xcc97
+
+  bool has_sse; // 0xcc97
+                // 0xcc98 (or 0xcc9b? who knows?)
 } __attribute__((packed));
 
 enum mem_entry_type {

--- a/src/kernel/include/kappldr.h
+++ b/src/kernel/include/kappldr.h
@@ -1,4 +1,5 @@
 #include "text.h"
+#include "misc.h"
 
 #pragma once
 
@@ -30,7 +31,7 @@ struct k_app {
 #define AVAILABLE_KAPPS 8
 typedef int app_handle;
 
-app_handle instantiate(struct k_app *, app_handle parent, char is_fg);
+app_handle instantiate(struct k_app *, app_handle parent, bool is_fg);
 void focus_app(app_handle which);
 void terminate_app(app_handle which);
 

--- a/src/kernel/include/printf.h
+++ b/src/kernel/include/printf.h
@@ -11,6 +11,7 @@
 typedef void (*putch_callback)(char ch, unsigned char style);
 
 void printf(const char *fmt, ...);
+void nprintf(unsigned int n, const char *fmt, ...);
 void sprintf(char *dest, const char *fmt, ...);
 void snprintf(char *dest, unsigned int n, const char *fmt, ...);
 void vpfctprintf(putch_callback put, const char *fmt, unsigned char start_style, va_list args);

--- a/src/kernel/include/sched.h
+++ b/src/kernel/include/sched.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "kappldr.h"
+
+typedef unsigned int tick_t;
+
+extern tick_t uptime;
+extern tick_t timed_invokes[AVAILABLE_KAPPS];
+
+void tick_focused_timed_invoke();
+void set_timed_invoke(app_handle app_id, tick_t delta);
+void clear_timed_invokes(app_handle app_id);

--- a/src/kernel/include/text.h
+++ b/src/kernel/include/text.h
@@ -120,7 +120,7 @@ void cur_on_with(unsigned char, unsigned char);
 
 void set_page(unsigned char pg);
 
-void paint_row(unsigned char);
+void paint_row(unsigned char colour);
 
 extern unsigned char is_split;
 void split_scr(int);

--- a/src/kernel/kappldr.c
+++ b/src/kernel/kappldr.c
@@ -5,11 +5,12 @@
 #include "include/text.h"
 #include "include/util.h"
 #include "include/memring.h"
+#include "include/sched.h"
 
 struct k_app *app_db[AVAILABLE_KAPPS];
 app_handle curr_kapp = -1;
 
-app_handle instantiate(struct k_app *app, app_handle parent, char is_fg) {
+app_handle instantiate(struct k_app *app, app_handle parent, bool is_fg) {
   app_handle found = -1;
   for (app_handle i = 0; i < AVAILABLE_KAPPS; ++i) {
     if (!app_db[i]) {
@@ -49,11 +50,16 @@ void focus_app(app_handle which) {
   }
   curr_kapp = which;
 //  (*app_db[curr_kapp]->virts->invoke)(app_db[curr_kapp]);
+
+  // if the program has a waiting invoke, do so
+  tick_focused_timed_invoke();
   
   set_page(which); // move to the page on which app is operating
 }
 
 void terminate_app(app_handle which) {
+  clear_timed_invokes(which);
+
   app_handle parent = app_db[which]->app_id >> 4;
   kapp_destroy(app_db[which]);
   app_db[which] = NULL; // no switching back

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -26,6 +26,7 @@ struct idtr_contents {
 } __attribute__((packed));
 
 extern void *eh_list[];
+extern bool sse_enable();
 
 void main() {
 //  clear_scr();
@@ -55,6 +56,9 @@ void main() {
   }
 
   asm volatile ("lidt %0" : : "m"(idtr)); // load idt
+
+  // enable sse
+  hardware->has_sse = sse_enable();
 
   pic_init(); // pic
   

--- a/src/kernel/misc.c
+++ b/src/kernel/misc.c
@@ -4,8 +4,8 @@
 struct far_ver * curr_ver = &((struct far_ver) {
   .major =    0,
   .minor =    0,
-  .patch =    5,
-  .build = 0x0d, // minor changes + hotfixes
+  .patch =    6,
+  .build = 0x00, // minor changes + hotfixes
 });
 
 struct farb_header __seg_fs *prog_head = 0;

--- a/src/kernel/printf.c
+++ b/src/kernel/printf.c
@@ -177,6 +177,10 @@ void vpfctprintf(putch_callback put, const char *fmt, unsigned char start_style,
             style = va_arg(args, unsigned int) & 0xff;
           }
           goto stop_waiting;
+        case '~': // character packet
+          struct char_packet pack = va_arg(args, struct char_packet);
+          put(pack.ch, pack.style);
+          goto stop_waiting;
         case '%':
           put('%', style);
           goto stop_waiting;

--- a/src/kernel/printf.c
+++ b/src/kernel/printf.c
@@ -32,6 +32,22 @@ void printf(const char* fmt, ...) {
   va_end(args);
 }
 
+void nprintf(unsigned int n, const char* fmt, ...) {
+  va_list args;
+  va_start(args, fmt); // second parameter is the last arg before variadic
+
+  int di = 0;
+  // XXX: gcc extension to use nested functions
+  void cb(char ch, unsigned char style) {
+    if (di < n) __wrapper_write_advanced_cell_cur(ch, style);
+    di++;
+  }
+
+  vpfctprintf(&cb, fmt, 0, args); // style doesn't matter: here we've just put 0
+
+  va_end(args);
+}
+
 // thin wrapper
 void sprintf(char *dest, const char* fmt, ...) {
   va_list args;

--- a/src/kernel/sched.c
+++ b/src/kernel/sched.c
@@ -1,0 +1,33 @@
+#include "include/kappldr.h"
+#include "include/err.h"
+#include "include/sched.h"
+
+// centisec (100ths of sec) since load
+tick_t uptime = 0;
+
+// list of ticks by which invokes should be timed. 
+tick_t timed_invokes[AVAILABLE_KAPPS];
+
+// check if invoke is due for the current focused app
+void tick_focused_timed_invoke() {
+  // if its less than uptime, but greater than zero, as zero means none set
+  if (timed_invokes[curr_kapp] && timed_invokes[curr_kapp] <= uptime) {
+    timed_invokes[curr_kapp] = 0; // reset
+    (*app_db[curr_kapp]->virts->invoke)(app_db[curr_kapp]);
+  }
+}
+
+// defacto wait
+void set_timed_invoke(app_handle app_id, tick_t delta) {
+  tick_t target = uptime + delta;
+  // replace timed invoke if either previous timed invoke has passed, or new timed invoke is sooner than old one
+  // this means that there can only ever be one timed invoke, and it is the soonest one.
+  // and if the app changes, this will lie waiting until next focus
+  if (timed_invokes[app_id] < uptime || timed_invokes[app_id] > target) {
+    timed_invokes[app_id] = target;
+  }
+}
+
+void clear_timed_invokes(app_handle app_id) {
+  timed_invokes[app_id] = 0;
+}


### PR DESCRIPTION
Added, as a kernel app, a physics simulator written in assembly using optimised MMX and SSE instructions as a demo of SIMD capabilities.

It consists of two "pieces" that obey gravity and bounce. The gravity can be flipped in the simulation at runtime, and also tilt (which acts as sideways gravity) can be added and increased/decreased at runtime. These two pieces are then projected onto the screen (taking into account whether split-screen is on to halve the size of the projection).

Unfortunately there is no builtin SIMD detection at this point: once the kernel apps are separated, then SIMD capabilities can be requested and denied if the CPU does not support it.

<img width="900" height="500" alt="image" src="https://github.com/user-attachments/assets/40417b8f-6ff6-4133-b463-a8714218d561" />

